### PR TITLE
cleaned up module 1.05 with errors in maven file and pom.xml

### DIFF
--- a/codelabs/Module1_SeleniumJava.md
+++ b/codelabs/Module1_SeleniumJava.md
@@ -170,7 +170,7 @@ Move the zipped file to your Applications folder.
 In terminal, open the file in your downloads directory in terminal and run the command:
 
 
-    `tar xzvf apache-maven-3.6.3-bin.tar.gz`.
+`tar xzvf apache-maven-3.6.3-bin.tar.gz`
 
 (Replace `maven-3.6.3-bin.tar.gz` with the version you downloaded.)  This will unzip the project file.
 
@@ -244,7 +244,7 @@ The `pom.xml` file is what Maven uses to identify which dependencies to install 
 
 
 ```
-?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -271,11 +271,13 @@ The `pom.xml` file is what Maven uses to identify which dependencies to install 
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java -->
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
             <version>4.0.0-alpha-1</version>
         </dependency>
+
 
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
@@ -290,10 +292,10 @@ The `pom.xml` file is what Maven uses to identify which dependencies to install 
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.9</source>
-                    <target>1.9</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -303,7 +305,7 @@ The `pom.xml` file is what Maven uses to identify which dependencies to install 
                     <parallel>methods</parallel>
                     <threadCount>40</threadCount>
                 </configuration>
-                <version>2.22.0</version>
+                <version>2.22.1</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Thank you for Contributing to Sauce School. Please add in the following to your PR:

<!--- Provide a general summary of your changes in the Title above -->

### Description
in module 1.05 of Java Course, the command to download the Maven file has errors, as did the pom.xml file. edited there and got them working

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/saucelabs/sauce-school/blob/master/CONTRIBUTING.MD) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
