### PR TITLE
[SSCH-23] Standardize CodeLab card styles, added missing TypeKit JS to all view indices

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ///start typing below this text
 
+## June 24 - Rich's Changes
+- Added missing Typekit script in all views/*/index.html head (lines 32 or 33)
+- Modified `.codelab-card` styles to match front page, corrected font weight and line height (_codelab-card.scss, 125-128)
+
 ## May 18 - Adekunle's Changes
 
 - Updated favicon in `site/app/images/favicons/browserconfig.xml`

--- a/site/app/styles/_codelab-card.scss
+++ b/site/app/styles/_codelab-card.scss
@@ -122,7 +122,10 @@ $card-col-height: 200px; // column mode
     width: 100%;
     text-align: left;
     display: inline-block;
+    line-height: 24px;
     padding: 10px 0px 15px 0px;
+    font-weight: 300;
+    font-size: 16px;
   }
 
   .card-duration {

--- a/site/app/views/SeleniumJava/index.html
+++ b/site/app/views/SeleniumJava/index.html
@@ -29,6 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     {% endif %}
   </script>
   <script async src='https://www.google-analytics.com/analytics.js'></script>
+  <script src="https://use.typekit.net/zmt8tam.js"></script><script>try{Typekit.load({ async: false });}catch(e){}</script>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=DEFAULT_GA">
   </script>

--- a/site/app/views/apiTesting/index.html
+++ b/site/app/views/apiTesting/index.html
@@ -29,6 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     {% endif %}
   </script>
   <script async src='https://www.google-analytics.com/analytics.js'></script>
+  <script src="https://use.typekit.net/zmt8tam.js"></script><script>try{Typekit.load({ async: false });}catch(e){}</script>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=DEFAULT_GA">
   </script>

--- a/site/app/views/quickstart/index.html
+++ b/site/app/views/quickstart/index.html
@@ -29,6 +29,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     {% endif %}
   </script>
   <script async src='https://www.google-analytics.com/analytics.js'></script>
+
+  <script src="https://use.typekit.net/zmt8tam.js"></script><script>try{Typekit.load({ async: false });}catch(e){}</script>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=DEFAULT_GA">
   </script>

--- a/site/app/views/sauceconnect/index.html
+++ b/site/app/views/sauceconnect/index.html
@@ -29,6 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     {% endif %}
   </script>
   <script async src='https://www.google-analytics.com/analytics.js'></script>
+  <script src="https://use.typekit.net/zmt8tam.js"></script><script>try{Typekit.load({ async: false });}catch(e){}</script>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=DEFAULT_GA">
   </script>

--- a/site/app/views/saucectl/index.html
+++ b/site/app/views/saucectl/index.html
@@ -29,6 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     {% endif %}
   </script>
   <script async src='https://www.google-analytics.com/analytics.js'></script>
+  <script src="https://use.typekit.net/zmt8tam.js"></script><script>try{Typekit.load({ async: false });}catch(e){}</script>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=DEFAULT_GA">
   </script>


### PR DESCRIPTION
### Description
- Added missing Typekit script in all views/*/index.html head (lines 32 or 33)
- Modified `.codelab-card` styles to match front page, corrected font weight and line height (_codelab-card.scss, 125-128)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Platform Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major Documentation Update (New modules, courses, or major re-orgamizations)
- [ ] Minor Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-school/blob/master/CONTRIBUTING.MD) document.
- [ ] For feature updates: I have updated the documentation [changelog.md](https://github.com/saucelabs/sauce-school/blob/master/changelog.md) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I ran tests before merging & [tests passed](https://github.com/saucelabs/sauce-school/blob/master/TESTING.md).
<!--- Provide a general summary of your changes in the Title above -->
