### PR TITLE
[SSCH-41] Update Default Base URL for Canonical tags

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 ### _Changelog- Add newest additions in an .md file at top_
 
 ///start typing below this text
+##June 30 - Rich's Changes
+- Modified default string for `gulpfile.js`'s default `BASE_URL` value to remove `example.com` artifact on certain pages. (gulpfile.js, 61)
 
 ## May 18 - Adekunle's Changes
 

--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -58,7 +58,7 @@ const DEFAULT_CATEGORY = 'Default';
 // BASE_URL is the canonical base URL where the site will reside. This should
 // always include the protocol (http:// or https://) and NOT including a
 // trailing slash.
-const BASE_URL = args.baseUrl || 'https://example.com';
+const BASE_URL = args.baseUrl || 'https://training.saucelabs.com';
 
 // CODELABS_DIR is the directory where the actual codelabs exist on disk.
 // Despite being a constant, this can be overridden with the --codelabs-dir


### PR DESCRIPTION
### Description
Modified default string for gulpfile.js's default BASE_URL value to remove example.com artifact generated on certain pages. (gulpfile.js, 61)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Platform Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major Documentation Update (New modules, courses, or major re-orgamizations)
- [ ] Minor Documentation fix (typos, incorrect content, missing content, etc.)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/saucelabs/sauce-school/blob/master/CONTRIBUTING.MD) document.
- [ ] For feature updates: I have updated the documentation [changelog.md](https://github.com/saucelabs/sauce-school/blob/master/changelog.md) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I ran tests before merging & [tests passed](https://github.com/saucelabs/sauce-school/blob/master/TESTING.md).
<!--- Provide a general summary of your changes in the Title above -->
